### PR TITLE
The godoc URL seems to be dead, updated the URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Run
 # Docs
 Docs are at [godoc.org][godoc]. 
 
-[godoc]: http://godoc.org/bitbucket.org/tebeka/selenium
+[godoc]: https://godoc.org/github.com/tebeka/selenium
 
 ## AppEngine
 


### PR DESCRIPTION
godoc.org URL(https://godoc.org/bitbucket.org/tebeka/selenium) seems to be not working, somehow I found this URL(https://godoc.org/github.com/tebeka/selenium) which is working. 
Can you please accept his pull request? 

Thanks for the client btw :)

