### PR TITLE
Add SetPageLoadTimeout to the driver API

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -388,6 +388,20 @@ func (wd *remoteWD) SetImplicitWaitTimeout(timeout time.Duration) error {
 	return wd.voidCommand("/session/%s/timeouts/implicit_wait", data)
 }
 
+func (wd *remoteWD) SetPageLoadTimeout(timeout time.Duration) error {
+	params := map[string]interface{}{
+		"ms":   uint(timeout / time.Millisecond),
+		"type": "page load",
+	}
+
+	data, err := json.Marshal(params)
+	if err != nil {
+		return err
+	}
+
+	return wd.voidCommand("/session/%s/timeouts", data)
+}
+
 func (wd *remoteWD) AvailableEngines() ([]string, error) {
 	return wd.stringsCommand("/session/%s/ime/available_engines")
 }

--- a/remote_test.go
+++ b/remote_test.go
@@ -108,6 +108,15 @@ func TestSetImplicitWaitTimeout(t *testing.T) {
 	}
 }
 
+func TestSetPageLoadTimeout(t *testing.T) {
+	wd := newRemote("TestSetPageLoadTimeout", t)
+	defer wd.Quit()
+
+	if err := wd.SetPageLoadTimeout(200); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestCurrentWindowHandle(t *testing.T) {
 	wd := newRemote("TestCurrentWindowHandle", t)
 	defer wd.Quit()

--- a/selenium.go
+++ b/selenium.go
@@ -154,6 +154,10 @@ type WebDriver interface {
 	Note that Selenium/WebDriver timeouts are in milliseconds, timeout will be rounded to nearest millisecond.
 	*/
 	SetImplicitWaitTimeout(timeout time.Duration) error
+	/* Set the amount of time, in milliseconds, the driver should wait when
+	loading a page.  Note that Selenium/WebDriver timeouts are in milliseconds,
+	timeout will be rounded to nearest millisecond.  */
+	SetPageLoadTimeout(timeout time.Duration) error
 
 	// IME
 	/* List all available engines on the machine. */


### PR DESCRIPTION
SetPageLoadTimeout sets the page load timeout.

Without this method, there is no way to write a test that simulates the user
pressing the "Stop" button after an arbitrary number of seconds has elapsed.