### PR TITLE
Add KeyUp and KeyDown to the element API

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -707,6 +707,19 @@ func (wd *remoteWD) SendModifier(modifier string, isDown bool) error {
 	return wd.voidCommand("/session/%s/modifier", data)
 }
 
+func (wd *remoteWD) KeyDown(keys string) error {
+	data, err := processKeyString(keys)
+	if err != nil {
+		return err
+	}
+
+	return wd.voidCommand("/session/%s/keys", data)
+}
+
+func (wd *remoteWD) KeyUp(keys string) error {
+	return wd.KeyDown(keys)
+}
+
 func (wd *remoteWD) DismissAlert() error {
 	return wd.voidCommand("/session/%s/dismiss_alert", nil)
 }
@@ -803,6 +816,16 @@ func (elem *remoteWE) Click() error {
 }
 
 func (elem *remoteWE) SendKeys(keys string) error {
+	data, err := processKeyString(keys)
+	if err != nil {
+		return err
+	}
+
+	urlTemplate := fmt.Sprintf("/session/%%s/element/%s/value", elem.id)
+	return elem.parent.voidCommand(urlTemplate, data)
+}
+
+func processKeyString(keys string) ([]byte, error) {
 	chars := make([]string, len(keys))
 	for i, c := range keys {
 		chars[i] = string(c)
@@ -813,11 +836,9 @@ func (elem *remoteWE) SendKeys(keys string) error {
 
 	data, err := json.Marshal(params)
 	if err != nil {
-		return err
+		return nil, err
 	}
-
-	urlTemplate := fmt.Sprintf("/session/%%s/element/%s/value", elem.id)
-	return elem.parent.voidCommand(urlTemplate, data)
+	return data, nil
 }
 
 func (elem *remoteWE) TagName() (string, error) {

--- a/remote_test.go
+++ b/remote_test.go
@@ -640,6 +640,28 @@ func TestResizeWindow(t *testing.T) {
 	}
 }
 
+func TestKeyDownUp(t *testing.T) {
+	wd := newRemote("TestKeyDownUp", t)
+	defer wd.Quit()
+
+	wd.Get(serverURL)
+
+	e, err := wd.FindElement(ByLinkText, "other page")
+	if err != nil {
+		t.Fatalf("error finding other page link: %v", err)
+	}
+
+	if err := wd.KeyDown(ControlKey); err != nil {
+		t.Fatalf("error pressing control key down: %v", err)
+	}
+	if err := e.Click(); err != nil {
+		t.Fatalf("error clicking the other page link: %v", err)
+	}
+	if err := wd.KeyUp(ControlKey); err != nil {
+		t.Fatalf("error releasing control key: %v", err)
+	}
+}
+
 // Test server
 
 var homePage = `
@@ -653,6 +675,7 @@ var homePage = `
 		<input name="q" /> <input type="submit" id="submit"/> <br />
 		<input id="chuk" type="checkbox" /> A checkbox.
 	</form>
+	Link to the <a href="/other">other page</a>.
 </body>
 </html>
 `

--- a/selenium.go
+++ b/selenium.go
@@ -245,6 +245,11 @@ type WebDriver interface {
 	modifier can be one of ShiftKey, ControlKey, AltKey, MetaKey.
 	*/
 	SendModifier(modifier string, isDown bool) error
+	/* Send a sequence of keystrokes to the active element. Similar to
+	SendKeys but without the implicit termination. Modifiers are not released
+	at the end of each call. */
+	KeyDown(keys string) error
+	KeyUp(keys string) error
 	/* Take a screenshot */
 	Screenshot() ([]byte, error)
 


### PR DESCRIPTION
KeyUp/KeyDown send keys to the active element without implicit termination of
modifier keys. This is the same API normally provided in other
languages.

Without these methods, we cannot perform modified clicks (Ctrl+click,
Shift+click). SendModifier should work for this purpose, but is deprecated and
non-functional.