### PR TITLE
Report more information from the server than "unknown error"

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -61,6 +61,10 @@ type remoteWD struct {
 type serverReply struct {
 	SessionId *string // sessionId can be null
 	Status    int
+	State     string
+	Value     struct {
+		Message interface{}
+	}
 }
 
 /* Various reply types, we use them to json.Unmarshal replies */
@@ -192,9 +196,13 @@ func (wd *remoteWD) execute(method, url string, data []byte) ([]byte, error) {
 		if err != nil {
 			return nil, errors.New(fmt.Sprintf("Bad server reply status: %s", response.Status))
 		}
-		message, ok := remoteErrors[reply.Status]
+
+		message, ok := reply.Value.Message.(string)
 		if !ok {
-			message = fmt.Sprintf("unknown error - %d", reply.Status)
+			message, ok = remoteErrors[reply.Status]
+			if !ok {
+				message = fmt.Sprintf("unknown error - %d", reply.Status)
+			}
 		}
 
 		return nil, errors.New(message)

--- a/remote.go
+++ b/remote.go
@@ -62,9 +62,7 @@ type serverReply struct {
 	SessionId *string // sessionId can be null
 	Status    int
 	State     string
-	Value     struct {
-		Message interface{}
-	}
+	Value     interface{}
 }
 
 /* Various reply types, we use them to json.Unmarshal replies */
@@ -197,11 +195,17 @@ func (wd *remoteWD) execute(method, url string, data []byte) ([]byte, error) {
 			return nil, errors.New(fmt.Sprintf("Bad server reply status: %s", response.Status))
 		}
 
-		message, ok := reply.Value.Message.(string)
+		message, ok := remoteErrors[reply.Status]
 		if !ok {
-			message, ok = remoteErrors[reply.Status]
-			if !ok {
-				message = fmt.Sprintf("unknown error - %d", reply.Status)
+			message = fmt.Sprintf("unknown error - %d", reply.Status)
+		}
+
+		if val, ok := reply.Value.(map[string]interface{}); ok {
+			_, exists := val["message"]
+			if exists {
+				if _message, ok := val["message"].(string); ok {
+					message = _message
+				}
 			}
 		}
 

--- a/remote.go
+++ b/remote.go
@@ -138,6 +138,18 @@ func cleanNils(buf []byte) {
 	}
 }
 
+func extractMessage(iVal interface{}) (msg string, ok bool) {
+	val := map[string]interface{}{}
+
+	if val, ok = iVal.(map[string]interface{}); ok {
+		if _, ok = val["message"]; ok {
+			msg, ok = val["message"].(string)
+		}
+	}
+
+	return
+}
+
 func isRedirect(response *http.Response) bool {
 	switch response.StatusCode {
 	case 301, 302, 303, 307:
@@ -200,13 +212,8 @@ func (wd *remoteWD) execute(method, url string, data []byte) ([]byte, error) {
 			message = fmt.Sprintf("unknown error - %d", reply.Status)
 		}
 
-		if val, ok := reply.Value.(map[string]interface{}); ok {
-			_, exists := val["message"]
-			if exists {
-				if _message, ok := val["message"].(string); ok {
-					message = _message
-				}
-			}
+		if moreDetailsMessage, ok := extractMessage(reply.Value); ok {
+			message = moreDetailsMessage
 		}
 
 		return nil, errors.New(message)


### PR DESCRIPTION
If more information is available (i.e.: can be unmarshaled and asserted as a string – there may be cases where serverReply.Value.Message is a not a string), it should be returned by webDriver.execute()