### PR TITLE
Added notes about possible need for gecko driver

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -7,6 +7,15 @@ like SauceLabs). The easiest way to do that is to grab the Selenium server jar
 from http://www.seleniumhq.org/download/ and run it
 	java -jar selenium-server-standalone-2.24.1.jar
 
+To use the webdriver with firefox, you may (depending on versions) require the
+gecko driver package. You can download it here
+        https://github.com/mozilla/geckodriver/releases
+and configure the webdriver in your Go code like this
+        caps := selenium.Capabilities{
+            "browserName":            "firefox",
+            "webdriver.gecko.driver": "/path/to/downloaded/geckodriver",
+        }
+        
 Example usage:
 
 	// Run some code on play.golang.org and display the result
@@ -32,8 +41,12 @@ Example usage:
 
 	func main() {
 		// FireFox driver without specific version
+		// *** Add gecko driver here if necessary (see notes above.) ***
 		caps := selenium.Capabilities{"browserName": "firefox"}
-		wd, _ := selenium.NewRemote(caps, "")
+		wd, err := selenium.NewRemote(caps, "")
+		if err != nil {
+			panic(err)
+		}
 		defer wd.Quit()
 
 		// Get simple playground interface


### PR DESCRIPTION
Wasn't sure about the best way to do this.

Have made the example code panic if `wd` is not initialised. If someone just cut-and-pastes the code without reading the notes then the panic message will tell them whether they need the gecko driver.