### PR TITLE
Improved (fixed?) remoteWD.SwitchFrame()

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -675,12 +675,12 @@ func (wd *remoteWD) ResizeWindow(name string, width, height int) error {
 	return err
 }
 
-func (wd *remoteWD) SwitchFrame(frame string) error {
+func (wd *remoteWD) SwitchFrame(we WebElement) error {
 	params := map[string]interface{}{
-		"id": frame,
+		"id": nil,
 	}
-	if len(frame) == 0 {
-		params["id"] = nil
+	if we != nil {
+		params["id"] = map[string]string{"ELEMENT": we.(*remoteWE).id}
 	}
 
 	data, err := json.Marshal(params)

--- a/selenium.go
+++ b/selenium.go
@@ -253,7 +253,7 @@ type WebDriver interface {
 	/* Close current window. */
 	Close() error
 	/* Switch to frame, frame parameter can be name or id. */
-	SwitchFrame(frame string) error
+	SwitchFrame(we WebElement) error
 	/* Switch to window. */
 	SwitchWindow(name string) error
 	/* Close window. */


### PR DESCRIPTION
I was head-desking for a while today trying to figure out what the SwitchFrame would accept so that I could enter text into a javascript textarea editor. I got various errors and eventually came up with this solution.

The good thing about this solution is that you can now use SelectElement first to find the iframe using any kind of selection mechanism you like. This code is lifted form my tests:

```go
	if iframe, err := wd.FindElement(selenium.ByCSSSelector, "iframe"); err != nil {
		return err
	} else if err := wd.SwitchFrame(iframe); err != nil {
		return err
	}
```

The thing I'm not sure about is that I'm using a type assertion to get a *remoteWE from a WebElement. I assume this is okay because mixing remoteWD with someOtherWE would not realistically be supported but I'm happy to be corrected on that. Is it okay to allow the code to panic if the type assertion fails? I really like panics when they scream "programmer error" but I know that many people deprecate them across package boundaries.