### PR TITLE
ChromeDriver returns cookie expiry dates as floats

### DIFF
--- a/remote_test.go
+++ b/remote_test.go
@@ -2,6 +2,7 @@ package selenium
 
 import (
 	"fmt"
+	"math"
 	"net/http"
 	"os"
 	"strings"
@@ -388,7 +389,11 @@ func TestAddCookie(t *testing.T) {
 	defer wd.Quit()
 
 	wd.Get(serverURL)
-	cookie := &Cookie{Name: "the nameless cookie", Value: "I have nothing"}
+	cookie := &Cookie{
+		Name:   "the nameless cookie",
+		Value:  "I have nothing",
+		Expiry: math.MaxUint32,
+	}
 	err := wd.AddCookie(cookie)
 	if err != nil {
 		t.Fatal(err)
@@ -399,7 +404,7 @@ func TestAddCookie(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, c := range cookies {
-		if (c.Name == cookie.Name) && (c.Value == cookie.Value) {
+		if (c.Name == cookie.Name) && (c.Value == cookie.Value) && (c.Expiry == math.MaxUint32) {
 			return
 		}
 	}


### PR DESCRIPTION
We change handling of the Expiry field of returned cookies to handle
both integer and float formats.

The following ChromeDriver commit changed the expiry field from an int
to a double to handle times far in the future.

https://chromium.googlesource.com/chromium/src.git/+/6cdce5554de9e4b686afc4cd9a934491ebae7fcc

The aspirational standard says it should be an int:

https://www.w3.org/TR/webdriver/#cookies

However, the various other clients seem to handle both. For example,
here is Java's implementation:

https://github.com/SeleniumHQ/selenium/blob/ab76d0ff9b38455e199d775e4e9da662eebb3f43/java/client/src/org/openqa/selenium/remote/RemoteWebDriver.java#L753