### PR TITLE
Explicit waits basic implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ selenium-server-standalone-*.jar
 chromedriver*
 vendor/*
 !vendor/*.go
+coverage.txt
+coverage.out

--- a/remote.go
+++ b/remote.go
@@ -44,16 +44,6 @@ var remoteErrors = map[int]string{
 	32: "invalid selector",
 }
 
-// Alias for a type that is passed as an argument for selenium.Wait
-type Condition func(wd WebDriver) (bool, error)
-
-// Default polling interval for selenium.Wait function.
-const DefaultWaitInterval = 100 * time.Millisecond
-
-// Default timeout for selenium.Wait function.
-const DefaultWaitTimeout = 60 * time.Second
-
-
 type remoteWD struct {
 	id, urlPrefix string
 	capabilities  Capabilities
@@ -1134,7 +1124,19 @@ func (wd *remoteWD) Screenshot() ([]byte, error) {
 	return ioutil.ReadAll(decoder)
 }
 
-func (wd *remoteWD) WaitWithTimeoutAndInterval(condition Condition, timeout time.Duration, interval time.Duration) (error) {
+// Condition is an alias for a type that is passed as an argument
+// for selenium.Wait(cond Condition) (error) function.
+type Condition func(wd WebDriver) (bool, error)
+
+const (
+	// Default polling interval for selenium.Wait function.
+	DefaultWaitInterval = 100 * time.Millisecond
+
+	// Default timeout for selenium.Wait function.
+	DefaultWaitTimeout = 60 * time.Second
+)
+
+func (wd *remoteWD) WaitWithTimeoutAndInterval(condition Condition, timeout, interval time.Duration) error {
 	startTime := time.Now()
 
 	for {
@@ -1142,24 +1144,22 @@ func (wd *remoteWD) WaitWithTimeoutAndInterval(condition Condition, timeout time
 		if err != nil {
 			return err
 		}
-
 		if done {
 			return nil
 		}
 
-		elapsed := time.Since(startTime)
-		if elapsed > timeout {
-			return fmt.Errorf("Timeout after %v", elapsed)
+		if elapsed := time.Since(startTime); elapsed > timeout {
+			return fmt.Errorf("timeout after %v", elapsed)
 		}
 		time.Sleep(interval)
 	}
 }
 
-func (wd *remoteWD) WaitWithTimeout(condition Condition, timeout time.Duration) (error){
+func (wd *remoteWD) WaitWithTimeout(condition Condition, timeout time.Duration) error {
 	return wd.WaitWithTimeoutAndInterval(condition, timeout, DefaultWaitInterval)
 }
 
-func (wd *remoteWD) Wait(condition Condition) (error) {
+func (wd *remoteWD) Wait(condition Condition) error {
 	return wd.WaitWithTimeoutAndInterval(condition, DefaultWaitTimeout, DefaultWaitInterval)
 }
 

--- a/remote_test.go
+++ b/remote_test.go
@@ -1634,22 +1634,24 @@ func testSwitchFrame(t *testing.T, c config) {
 	}
 }
 
-func titleChangeCondition(wd WebDriver) (bool, error) {
-	title, err := wd.Title()
-	if err != nil {
-		return false, err
+func testWait(t *testing.T, c config) {
+	newTitle := "Title changed."
+	titleChangeCondition:= func (wd WebDriver) (bool, error) {
+		title, err := wd.Title()
+		if err != nil {
+			return false, err
+		}
+
+		return title == newTitle, nil
 	}
 
-	fmt.Printf("title \"%s\"\n", title)
-	return title == "Title changed.", nil
-}
-
-func testWait(t *testing.T, c config) {
 	wd := newRemote(t, c)
 	defer quitRemote(t, wd)
 
-	if err := wd.Get(serverURL + "/title"); err != nil {
-		t.Fatalf("wd.Get(%q) returned error: %v", serverURL, err)
+	titleURL := serverURL + "/title"
+
+	if err := wd.Get(titleURL); err != nil {
+		t.Fatalf("wd.Get(%q) returned error: %v", titleURL, err)
 	}
 
 	// Testing when the title should change.
@@ -1657,13 +1659,13 @@ func testWait(t *testing.T, c config) {
 		t.Fatalf("wd.Wait(titleChangeCondition) returned error: %v", err)
 	}
 
-	// Reloading the page
-	if err := wd.Get(serverURL + "/title"); err != nil {
-		t.Fatalf("wd.Get(%q) returned error: %v", serverURL, err)
+	// Reloading the page.
+	if err := wd.Get(titleURL); err != nil {
+		t.Fatalf("wd.Get(%q) returned error: %v", titleURL, err)
 	}
 
 	// Testing when the Wait() should error the timeout..
-	if err := wd.WaitWithTimeout(titleChangeCondition, 3*time.Second); err == nil {
+	if err := wd.WaitWithTimeout(titleChangeCondition, 500*time.Millisecond); err == nil {
 		t.Fatalf("wd.Wait(titleChangeCondition) should returned error, but it didn't.")
 	}
 }
@@ -1749,10 +1751,10 @@ var titleChangePage = `
 	<title>Go Selenium Test Suite - Title Change Page</title>
 </head>
 <body>
-	This page will change a title after 5 seconds.
+	This page will change a title after 1 second.
 
 	<script>
-		setTimeout(function() { document.title = 'Title changed.' }, 5000);
+		setTimeout(function() { document.title = 'Title changed.' }, 1000);
 	</script>
 </body>
 </html>

--- a/remote_test.go
+++ b/remote_test.go
@@ -1635,8 +1635,8 @@ func testSwitchFrame(t *testing.T, c config) {
 }
 
 func testWait(t *testing.T, c config) {
-	newTitle := "Title changed."
-	titleChangeCondition:= func (wd WebDriver) (bool, error) {
+	const newTitle = "Title changed."
+	titleChangeCondition := func(wd WebDriver) (bool, error) {
 		title, err := wd.Title()
 		if err != nil {
 			return false, err

--- a/remote_test.go
+++ b/remote_test.go
@@ -494,6 +494,7 @@ func runTests(t *testing.T, c config) {
 	t.Run("CSSProperty", runTest(testCSSProperty, c))
 	t.Run("Proxy", runTest(testProxy, c))
 	t.Run("SwitchFrame", runTest(testSwitchFrame, c))
+	t.Run("Wait", runTest(testWait, c))
 	t.Run("ActiveElement", runTest(testActiveElement, c))
 }
 
@@ -1633,6 +1634,40 @@ func testSwitchFrame(t *testing.T, c config) {
 	}
 }
 
+func titleChangeCondition(wd WebDriver) (bool, error) {
+	title, err := wd.Title()
+	if err != nil {
+		return false, err
+	}
+
+	fmt.Printf("title \"%s\"\n", title)
+	return title == "Title changed.", nil
+}
+
+func testWait(t *testing.T, c config) {
+	wd := newRemote(t, c)
+	defer quitRemote(t, wd)
+
+	if err := wd.Get(serverURL + "/title"); err != nil {
+		t.Fatalf("wd.Get(%q) returned error: %v", serverURL, err)
+	}
+
+	// Testing when the title should change.
+	if err := wd.Wait(titleChangeCondition); err != nil {
+		t.Fatalf("wd.Wait(titleChangeCondition) returned error: %v", err)
+	}
+
+	// Reloading the page
+	if err := wd.Get(serverURL + "/title"); err != nil {
+		t.Fatalf("wd.Get(%q) returned error: %v", serverURL, err)
+	}
+
+	// Testing when the Wait() should error the timeout..
+	if err := wd.WaitWithTimeout(titleChangeCondition, 3*time.Second); err == nil {
+		t.Fatalf("wd.Wait(titleChangeCondition) should returned error, but it didn't.")
+	}
+}
+
 var homePage = `
 <html>
 <head>
@@ -1708,6 +1743,21 @@ var framePage = `
 </html>
 `
 
+var titleChangePage = `
+<html>
+<head>
+	<title>Go Selenium Test Suite - Title Change Page</title>
+</head>
+<body>
+	This page will change a title after 5 seconds.
+
+	<script>
+		setTimeout(function() { document.title = 'Title changed.' }, 5000);
+	</script>
+</body>
+</html>
+`
+
 func handler(w http.ResponseWriter, r *http.Request) {
 	path := r.URL.Path
 	page, ok := map[string]string{
@@ -1716,6 +1766,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		"/search": searchPage,
 		"/log":    logPage,
 		"/frame":  framePage,
+		"/title":  titleChangePage,
 	}[path]
 	if !ok {
 		http.NotFound(w, r)

--- a/selenium.go
+++ b/selenium.go
@@ -358,6 +358,15 @@ type WebDriver interface {
 	// ExecuteScriptAsyncRaw asynchronously executes a script but does not
 	// perform JSON decoding.
 	ExecuteScriptAsyncRaw(script string, args []interface{}) ([]byte, error)
+
+	// WaitWithTimeoutAndInterval waits for the condition to evaluate to true.
+	WaitWithTimeoutAndInterval(condition Condition, timeout time.Duration, interval time.Duration) (error)
+
+	// WaitWithTimeout works like WaitWithTimeoutAndInterval, but with default polling interval.
+	WaitWithTimeout(condition Condition, timeout time.Duration) (error)
+
+	//Wait works like WaitWithTimeoutAndInterval, but using the default timeout and polling interval.
+	Wait(condition Condition) (error)
 }
 
 // WebElement defines method supported by web elements.

--- a/selenium.go
+++ b/selenium.go
@@ -360,13 +360,13 @@ type WebDriver interface {
 	ExecuteScriptAsyncRaw(script string, args []interface{}) ([]byte, error)
 
 	// WaitWithTimeoutAndInterval waits for the condition to evaluate to true.
-	WaitWithTimeoutAndInterval(condition Condition, timeout time.Duration, interval time.Duration) (error)
+	WaitWithTimeoutAndInterval(condition Condition, timeout, interval time.Duration) error
 
 	// WaitWithTimeout works like WaitWithTimeoutAndInterval, but with default polling interval.
-	WaitWithTimeout(condition Condition, timeout time.Duration) (error)
+	WaitWithTimeout(condition Condition, timeout time.Duration) error
 
 	//Wait works like WaitWithTimeoutAndInterval, but using the default timeout and polling interval.
-	Wait(condition Condition) (error)
+	Wait(condition Condition) error
 }
 
 // WebElement defines method supported by web elements.


### PR DESCRIPTION
Explicit waits implementation for this binding.

I've tested it with this example (this is slightly changed example from this library), check this out:

```go
package main

import (
	"time"
	"fmt"

	"github.com/tebeka/selenium"
)

func tillContentChange(wd selenium.WebDriver) (bool, error) {
	outputDiv, err := wd.FindElement(selenium.ByCSSSelector, "#output")
	if err != nil {
		return false, err
	}

	output, err := outputDiv.Text()
	if err != nil {
		return false, err
	}

	return output != "Waiting for remote server..." && output != "", nil
}

func main() {
	caps := selenium.Capabilities{"browserName": "firefox"}
	wd, err := selenium.NewRemote(caps, "")
	if err != nil {
		panic(err)
	}
	defer wd.Quit()

	if err := wd.Get("http://play.golang.org/?simple=1"); err != nil {
		panic(err)
	}

	elem, err := wd.FindElement(selenium.ByCSSSelector, "#code")
	if err != nil {
		panic(err)
	}
	if err := elem.Clear(); err != nil {
		panic(err)
	}

	err = elem.SendKeys(`
		package main
		import (
			"fmt"
			"time"
		)

		func main() {
			time.Sleep(10 * time.Second)
			fmt.Println("Hello WebDriver!\n")
		}
	`)
	if err != nil {
		panic(err)
	}

	btn, err := wd.FindElement(selenium.ByCSSSelector, "#run")
	if err != nil {
		panic(err)
	}
	if err := btn.Click(); err != nil {
		panic(err)
	}

	if err := wd.WaitWithTimeoutAndInterval(tillContentChange, 15 * time.Second, 1 * time.Second); err != nil {
		panic(err)
	}

	outputDiv, err := wd.FindElement(selenium.ByCSSSelector, "#output")
	if err != nil {
		panic(err)
	}

	output, err := outputDiv.Text();
	if err != nil {
		panic(err)
	}

	fmt.Printf("Got: %s\n", output)
}

```

You can also try using `wd.Wait(tillContentChange)` and `wd.WaitWithTimeout(some_timeout)` to check it.

Also try changing `15 * time.Second` to `5 * time.Second` so it would return an error instead.

Any changes/proposals are welcome!