### PR TITLE
DeviceMetrics field should be a pointer

### DIFF
--- a/chrome/capabilities.go
+++ b/chrome/capabilities.go
@@ -75,7 +75,7 @@ type MobileEmulation struct {
 	DeviceName string `json:"deviceName,omitempty"`
 	// DeviceMetrics provides specifications of an device to emulate. It should
 	// not be set if DeviceName is set.
-	DeviceMetrics DeviceMetrics `json:"deviceMetrics,omitempty"`
+	DeviceMetrics *DeviceMetrics `json:"deviceMetrics,omitempty"`
 	// UserAgent specifies the user agent string to send to the remote web
 	// server.
 	UserAgent string `json:"userAgent,omitempty"`


### PR DESCRIPTION
`MobileEmulation.DeviceMetrics` field should be a pointer if we rely on "omitempty" json attr during marshaling. Otherwise it's not ignored:

```
-> POST http://localhost:9515/wd/hub/session
{
	...
    "desiredCapabilities": {
        "chromeOptions": {
        	...
            "mobileEmulation": {
                "deviceName": "iPhone 6 Plus",
                "deviceMetrics": { // <- oops
                    "width": 0,
                    "height": 0,
                    "pixelRatio": 0
                }
            }
        }
    }
}
```

And remote runs into this error:

```
[1.705][INFO]: RESPONSE InitSession unknown error: cannot parse capability: chromeOptions
from unknown error: cannot parse mobileEmulation
from unknown error: 'deviceName' must be used alone
```

Windows 10, go 1.9, chromedriver 2.31