### PR TITLE
Fix race condition in vendor/init.go

### DIFF
--- a/vendor/init.go
+++ b/vendor/init.go
@@ -111,12 +111,12 @@ func addChrome(ctx context.Context) error {
 func main() {
 	flag.Parse()
 	ctx := context.Background()
-	wg := sync.WaitGroup{}
 	if *downloadBrowsers {
 		if err := addChrome(ctx); err != nil {
 			glog.Errorf("unable to Download Google Chrome browser: %v", err)
 		}
 	}
+	var wg sync.WaitGroup
 	for _, file := range files {
 		wg.Add(1)
 		file := file

--- a/vendor/init.go
+++ b/vendor/init.go
@@ -113,13 +113,9 @@ func main() {
 	ctx := context.Background()
 	wg := sync.WaitGroup{}
 	if *downloadBrowsers {
-		wg.Add(1)
-		go func() {
-			if err := addChrome(ctx); err != nil {
-				glog.Errorf("unable to Download Google Chrome browser: %v", err)
-			}
-			wg.Done()
-		}()
+		if err := addChrome(ctx); err != nil {
+			glog.Errorf("unable to Download Google Chrome browser: %v", err)
+		}
 	}
 	for _, file := range files {
 		wg.Add(1)


### PR DESCRIPTION
This was introduced in [1]. When --download_browsers is true, addChrome() would be run in parallel with iterating through the list of files. However, addChrome just appends the latest Chrome release to that list of files. This results in the Chrome file not being present in the files download list, and not being downloaded even with --download_browsers being true.

[1] https://github.com/tebeka/selenium/commit/a43e0e18ec302db0a1f6e274abe87928c882da34