### PR TITLE
Expand selenium.Display to accept screen numbers.

### DIFF
--- a/service.go
+++ b/service.go
@@ -28,7 +28,7 @@ func Display(d, xauthPath string) ServiceOption {
 		if s.xauthPath != "" {
 			return fmt.Errorf("service xauth path already set: %v", s.xauthPath)
 		}
-		if _, err := strconv.Atoi(d); err != nil {
+		if !isDisplay(d) {
 			return fmt.Errorf("supplied display %q must be of the format 'x' or 'x.y' where x and y are integers", d)
 		}
 		s.display = d

--- a/service.go
+++ b/service.go
@@ -29,12 +29,28 @@ func Display(d, xauthPath string) ServiceOption {
 			return fmt.Errorf("service xauth path already set: %v", s.xauthPath)
 		}
 		if _, err := strconv.Atoi(d); err != nil {
-			return fmt.Errorf("supplied display %q must be an integer as a string", d)
+			return fmt.Errorf("supplied display %q must be of the format x or x.y where x and y are integers", d)
 		}
 		s.display = d
 		s.xauthPath = xauthPath
 		return nil
 	}
+}
+
+// isDisplay validates that the given disp is in the format "x" or "x.y", where
+// x and y are both integers.
+func isDisplay(disp string) bool {
+	ds := strings.Split(disp, ".")
+	if len(ds) > 2 {
+		return false
+	}
+
+	for _, d := range ds {
+		if _, err := strconv.Atoi(d); err != nil {
+			return false
+		}
+	}
+	return true
 }
 
 // StartFrameBuffer causes an X virtual frame buffer to start before the

--- a/service.go
+++ b/service.go
@@ -29,7 +29,7 @@ func Display(d, xauthPath string) ServiceOption {
 			return fmt.Errorf("service xauth path already set: %v", s.xauthPath)
 		}
 		if _, err := strconv.Atoi(d); err != nil {
-			return fmt.Errorf("supplied display %q must be of the format x or x.y where x and y are integers", d)
+			return fmt.Errorf("supplied display %q must be of the format 'x' or 'x.y' where x and y are integers", d)
 		}
 		s.display = d
 		s.xauthPath = xauthPath

--- a/service_test.go
+++ b/service_test.go
@@ -1,0 +1,68 @@
+package selenium
+
+import "testing"
+
+func TestIsDisplay(t *testing.T) {
+	tests := []struct {
+		desc  string
+		in    string
+		valid bool
+	}{
+		{
+			desc:  "valid with just display",
+			in:    "2",
+			valid: true,
+		},
+		{
+			desc:  "valid with display and screen",
+			in:    "2.5",
+			valid: true,
+		},
+		{
+			desc:  "invalid with non-numeric display",
+			in:    "a",
+			valid: false,
+		},
+		{
+			desc:  "invalid with non-numeric display and screen",
+			in:    "a.5",
+			valid: false,
+		},
+		{
+			desc:  "invalid with display and non-numeric screen",
+			in:    "2.b",
+			valid: false,
+		},
+		{
+			desc:  "invalid with display and blank screen",
+			in:    "2.",
+			valid: false,
+		},
+		{
+			desc:  "invalid with blank display and screen",
+			in:    ".3",
+			valid: false,
+		},
+		{
+			desc:  "invalid with blank display and blank screen",
+			in:    ".",
+			valid: false,
+		},
+		{
+			desc:  "blank string is invalid",
+			in:    "",
+			valid: false,
+		},
+		{
+			desc:  "malformed input",
+			in:    "2.5.7",
+			valid: false,
+		},
+	}
+
+	for _, test := range tests {
+		if got, want := isDisplay(test.in), test.valid; got != want {
+			t.Errorf("%s: isDisplay = %t, want %t", test.desc, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Previously, if you ran a single Xvfb display with multiple screens, you
couldn't pass them to selenium.Display because it would fail on the
input "x.y", which is a perfectly valid $DISPLAY value. See [1] for more
information.

[1] https://docstore.mik.ua/orelly/unix3/upt/ch35_08.htm