### PR TITLE
Allow non-integer element sizes.

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -1387,11 +1387,11 @@ func (elem *remoteWE) Size() (*Size, error) {
 		if err != nil {
 			return nil, err
 		}
-		reply := new(struct{ Value Size })
+		reply := make(struct{ Value rect })
 		if err := json.Unmarshal(response, reply); err != nil {
 			return nil, err
 		}
-		return &reply.Value, nil
+		return &Size{round(reply.Value.Width), round(reply.Value.Height)}, nil
 	}
 
 	rect, err := elem.rect()
@@ -1399,7 +1399,7 @@ func (elem *remoteWE) Size() (*Size, error) {
 		return nil, err
 	}
 
-	return &Size{int(rect.Width), int(rect.Height)}, nil
+	return &Size{round(rect.Width), round(rect.Height)}, nil
 }
 
 type rect struct {

--- a/remote.go
+++ b/remote.go
@@ -1387,7 +1387,7 @@ func (elem *remoteWE) Size() (*Size, error) {
 		if err != nil {
 			return nil, err
 		}
-		reply := make(struct{ Value rect })
+		reply := new(struct{ Value rect })
 		if err := json.Unmarshal(response, reply); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Some driver/browser combinations may return non-integer sizes.