### PR TITLE
Added new goog:chromeOptions key.

### DIFF
--- a/chrome/capabilities.go
+++ b/chrome/capabilities.go
@@ -17,9 +17,10 @@ import (
 	"github.com/tebeka/selenium/internal/zip"
 )
 
-// CapabilitiesKey is the key in the top-level Capabilities map under which
+// DeprecatedCapabilitiesKey and CapabilitiesKey are the key in the top-level Capabilities map under which
 // ChromeDriver expects the Chrome-specific options to be set.
-const CapabilitiesKey = "chromeOptions"
+const DeprecatedCapabilitiesKey = "chromeOptions"
+const CapabilitiesKey = "goog:chromeOptions"
 
 // Capabilities defines the Chrome-specific desired capabilities when using
 // ChromeDriver. An instance of this struct can be stored in the Capabilities

--- a/selenium.go
+++ b/selenium.go
@@ -95,6 +95,7 @@ type Capabilities map[string]interface{}
 // AddChrome adds Chrome-specific capabilities.
 func (c Capabilities) AddChrome(f chrome.Capabilities) {
 	c[chrome.CapabilitiesKey] = f
+	c[chrome.DeprecatedCapabilitiesKey] = f
 }
 
 // AddFirefox adds Firefox-specific capabilities.


### PR DESCRIPTION
Starting with Selenium 3.8 the default `chromeOptions` are ignored on selenium chrome instances, instead `goog:chromeOptions` is the new key.
https://github.com/elgalu/docker-selenium/issues/201

This adds the new `goog:chromeOptions` key while keeping the older `chromeOptions` key, selenium ignores the extra parameters sent to it and uses only the correct one.