### PR TITLE
Expose the frame buffer and allow the user to specify options when creating a frame buffer.

### DIFF
--- a/command_test.go
+++ b/command_test.go
@@ -1,0 +1,81 @@
+package selenium
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeExecCommand is a replacement for `exec.Command` that we can control
+// using the TestHelperProcess function.
+//
+// For more information, see:
+// * https://npf.io/2015/06/testing-exec-command/
+// * https://golang.org/src/os/exec/exec_test.go
+func fakeExecCommand(command string, args ...string) *exec.Cmd {
+	// Use `go test` to run the `TestHelperProcess` test with our arguments.
+	cs := []string{"-test.run=TestHelperProcess", "--", command}
+	cs = append(cs, args...)
+	cmd := exec.Command(os.Args[0], cs...)
+	cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}
+	return cmd
+}
+
+func TestHelperProcess(t *testing.T) {
+	// If this function (which masquerades as a test) is run on its own, then
+	// just return quietly.
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+
+	args := os.Args
+	for len(args) > 0 {
+		if args[0] == "--" {
+			args = args[1:]
+			break
+		}
+		args = args[1:]
+	}
+	if len(args) == 0 {
+		fmt.Fprintf(os.Stderr, "No command\n")
+		os.Exit(2)
+	}
+
+	cmd, args := args[0], args[1:]
+	switch cmd {
+	case "echo":
+		fmt.Printf("%s\n", strings.Join(args, " "))
+		os.Exit(0)
+	case "Xvfb":
+		// Print out the X11 screen of "1".
+		screenNumber := "1"
+		file := os.NewFile(uintptr(3), "pipe")
+		_, err := file.Write([]byte(screenNumber + "\n"))
+		if err != nil {
+			panic(err)
+		}
+		time.Sleep(time.Second * 3)
+		file.Close()
+		os.Exit(0)
+	case "xauth":
+		os.Exit(0)
+	}
+
+	fmt.Fprintf(os.Stderr, "%s: command not found\n", cmd)
+	os.Exit(127)
+}
+
+func TestFakeExecCommand(t *testing.T) {
+	cmd := fakeExecCommand("echo", "hello", "world")
+	outputBytes, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("Could not get output: %s", err.Error())
+	}
+	outputString := string(outputBytes)
+	if outputString != "hello world\n" {
+		t.Fatalf("outputString = %s, want = %s", outputString, "hello world\n")
+	}
+}

--- a/service_test.go
+++ b/service_test.go
@@ -66,3 +66,79 @@ func TestIsDisplay(t *testing.T) {
 		}
 	}
 }
+
+func TestFrameBuffer(t *testing.T) {
+	// Make sure that we are using our unit-test version of `exec.Command`.
+	newExecCommand = fakeExecCommand
+
+	t.Run("Default behavior", func(t *testing.T) {
+		frameBuffer, err := NewFrameBuffer()
+		if err != nil {
+			t.Fatalf("Could not create frame buffer: %s", err.Error())
+		}
+		if frameBuffer.Display != "1" {
+			t.Errorf("frameBuffer.Display = %s, want %s", frameBuffer.Display, "1")
+		}
+		args := frameBuffer.cmd.Args[3:]
+		if len(args) != 5 {
+			t.Errorf("args length = %d, want = %d", len(args), 5)
+		} else {
+			if args[0] != "Xvfb" {
+				t.Errorf("args[0] = %s, want = %s", args[0], "Xvfb")
+			}
+			if args[1] != "-displayfd" {
+				t.Errorf("args[1] = %s, want = %s", args[1], "-displayfd")
+			}
+			if args[2] != "3" {
+				t.Errorf("args[2] = %s, want = %s", args[2], "3")
+			}
+			if args[3] != "-nolisten" {
+				t.Errorf("args[3] = %s, want = %s", args[3], "-nolisten")
+			}
+			if args[4] != "tcp" {
+				t.Errorf("args[4] = %s, want = %s", args[4], "tcp")
+			}
+		}
+	})
+	t.Run("With screen size", func(t *testing.T) {
+		options := FrameBufferOptions{
+			ScreenSize: "1024x768x24",
+		}
+		frameBuffer, err := NewFrameBufferWithOptions(options)
+		if err != nil {
+			t.Fatalf("Could not create frame buffer: %s", err.Error())
+		}
+		if frameBuffer.Display != "1" {
+			t.Errorf("frameBuffer.Display = %s, want %s", frameBuffer.Display, "1")
+		}
+		args := frameBuffer.cmd.Args[3:]
+		if len(args) != 8 {
+			t.Errorf("args length = %d, want = %d", len(args), 8)
+		} else {
+			if args[0] != "Xvfb" {
+				t.Errorf("args[0] = %s, want = %s", args[0], "Xvfb")
+			}
+			if args[1] != "-displayfd" {
+				t.Errorf("args[1] = %s, want = %s", args[1], "-displayfd")
+			}
+			if args[2] != "3" {
+				t.Errorf("args[2] = %s, want = %s", args[2], "3")
+			}
+			if args[3] != "-nolisten" {
+				t.Errorf("args[3] = %s, want = %s", args[3], "-nolisten")
+			}
+			if args[4] != "tcp" {
+				t.Errorf("args[4] = %s, want = %s", args[4], "tcp")
+			}
+			if args[5] != "-screen" {
+				t.Errorf("args[5] = %s, want = %s", args[5], "-screen")
+			}
+			if args[6] != "0" {
+				t.Errorf("args[6] = %s, want = %s", args[6], "0")
+			}
+			if args[7] != options.ScreenSize {
+				t.Errorf("args[7] = %s, want = %s", args[7], options.ScreenSize)
+			}
+		}
+	})
+}

--- a/service_test.go
+++ b/service_test.go
@@ -1,6 +1,10 @@
 package selenium
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
 
 func TestIsDisplay(t *testing.T) {
 	tests := []struct {
@@ -80,24 +84,9 @@ func TestFrameBuffer(t *testing.T) {
 			t.Errorf("frameBuffer.Display = %s, want %s", frameBuffer.Display, "1")
 		}
 		args := frameBuffer.cmd.Args[3:]
-		if len(args) != 5 {
-			t.Errorf("args length = %d, want = %d", len(args), 5)
-		} else {
-			if args[0] != "Xvfb" {
-				t.Errorf("args[0] = %s, want = %s", args[0], "Xvfb")
-			}
-			if args[1] != "-displayfd" {
-				t.Errorf("args[1] = %s, want = %s", args[1], "-displayfd")
-			}
-			if args[2] != "3" {
-				t.Errorf("args[2] = %s, want = %s", args[2], "3")
-			}
-			if args[3] != "-nolisten" {
-				t.Errorf("args[3] = %s, want = %s", args[3], "-nolisten")
-			}
-			if args[4] != "tcp" {
-				t.Errorf("args[4] = %s, want = %s", args[4], "tcp")
-			}
+		expectedArgs := []string{"Xvfb", "-displayfd", "3", "-nolisten", "tcp"}
+		if diff := cmp.Diff(expectedArgs, args); diff != "" {
+			t.Fatalf("args returned diff (-want/+got):\n%s", diff)
 		}
 	})
 	t.Run("With screen size", func(t *testing.T) {
@@ -112,33 +101,18 @@ func TestFrameBuffer(t *testing.T) {
 			t.Errorf("frameBuffer.Display = %s, want %s", frameBuffer.Display, "1")
 		}
 		args := frameBuffer.cmd.Args[3:]
-		if len(args) != 8 {
-			t.Errorf("args length = %d, want = %d", len(args), 8)
-		} else {
-			if args[0] != "Xvfb" {
-				t.Errorf("args[0] = %s, want = %s", args[0], "Xvfb")
-			}
-			if args[1] != "-displayfd" {
-				t.Errorf("args[1] = %s, want = %s", args[1], "-displayfd")
-			}
-			if args[2] != "3" {
-				t.Errorf("args[2] = %s, want = %s", args[2], "3")
-			}
-			if args[3] != "-nolisten" {
-				t.Errorf("args[3] = %s, want = %s", args[3], "-nolisten")
-			}
-			if args[4] != "tcp" {
-				t.Errorf("args[4] = %s, want = %s", args[4], "tcp")
-			}
-			if args[5] != "-screen" {
-				t.Errorf("args[5] = %s, want = %s", args[5], "-screen")
-			}
-			if args[6] != "0" {
-				t.Errorf("args[6] = %s, want = %s", args[6], "0")
-			}
-			if args[7] != options.ScreenSize {
-				t.Errorf("args[7] = %s, want = %s", args[7], options.ScreenSize)
-			}
+		expectedArgs := []string{"Xvfb", "-displayfd", "3", "-nolisten", "tcp", "-screen", "0", options.ScreenSize}
+		if diff := cmp.Diff(expectedArgs, args); diff != "" {
+			t.Fatalf("args returned diff (-want/+got):\n%s", diff)
+		}
+	})
+	t.Run("With bad screen size", func(t *testing.T) {
+		options := FrameBufferOptions{
+			ScreenSize: "not a screen size",
+		}
+		_, err := NewFrameBufferWithOptions(options)
+		if err == nil {
+			t.Fatalf("Expected an error about the screen size")
 		}
 	})
 }


### PR DESCRIPTION
I want to be able to save my runs as MP4 files, and that means that I need to know the X11 display number so I can pass it to `avconv`.  I also want to be able to specify the screen size so that my tests can run against multiple resolutions.

This commit:

1. Exposes the frame buffer so that users can determine the display.
2. Allows you to pass options when creating a frame buffer.

The only option right now is for screen size, in particular so that you can set the color depth (the 8-bit default is no good for humans). Because the X11 display is exposed, you can write your own code to record from that display or take screenshots.

I created a new way to create a `FrameBuffer` called `NewFrameBufferWithOptions`, which accepts a map of options.  I saw some todo items in there for doing other things; this options mechanism would allow for that without breaking the signature.  I kept the old `NewFrameBuffer` for compatibility purposes, but it just calls the new one with no options.

Likewise, I created a new way to create a frame buffer `ServiceOption` called `StartFrameBufferWithOptions`, which accepts a map of options and passes them on to `NewFrameBufferWithOptions`.  Again, to maintain compatibility, I kept `StartFrameBuffer`, which just calls the new one with no options.