### PR TITLE
Windows OS: hide background browser driver's console window

### DIFF
--- a/service.go
+++ b/service.go
@@ -10,8 +10,10 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -205,6 +207,11 @@ func newService(cmd *exec.Cmd, port int, opts ...ServiceOption) (*Service, error
 	cmd.Stderr = s.output
 	cmd.Stdout = s.output
 	cmd.Env = os.Environ()
+
+	if runtime.GOOS == "windows" {
+		cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+	}
+	
 	// TODO(minusnine): Pdeathsig is only supported on Linux. Somehow, make sure
 	// process cleanup happens as gracefully as possible.
 	if s.display != "" {


### PR DESCRIPTION
Hide background browser driver's console window on windows.