### PR TITLE
fix service.start

### DIFF
--- a/service.go
+++ b/service.go
@@ -230,7 +230,8 @@ func (s *Service) start(port int) error {
 			switch resp.StatusCode {
 			// Selenium <3 returned Forbidden and BadRequest. ChromeDriver and
 			// Selenium 3 return OK.
-			case http.StatusForbidden, http.StatusBadRequest, http.StatusOK:
+			// Selenium 3.14 returned 404
+			case http.StatusForbidden, http.StatusBadRequest, http.StatusNotFound, http.StatusOK:
 				return nil
 			}
 		}


### PR DESCRIPTION
in the service.start function,
https://github.com/tebeka/selenium/blob/a49cf4b98a36c2b21b1ccb012852bd142d5fc04a/service.go#L220-L239
http.StatusForbidden, http.StatusBadRequest, http.StatusOK are considered as right,and the other http code are wrong.
but in the selenium3.14,the url `http://localhost:8080/status` will return 404 which is considered as wrong.

**selenium3.4 return 200**
![snipaste20180913_162830](https://user-images.githubusercontent.com/2113954/45476873-b1168d00-b772-11e8-9eb0-f12df45da0b6.png)

**selenium3.14 return 404**
![snipaste20180913_163243](https://user-images.githubusercontent.com/2113954/45476878-b673d780-b772-11e8-8863-90174e11a541.png)

so,I add `http.StatusNotFound`
