### PR TITLE
Support the `W3C` capability for Chrome

### DIFF
--- a/chrome/capabilities.go
+++ b/chrome/capabilities.go
@@ -67,7 +67,7 @@ type Capabilities struct {
 	// Android Chrome WebDriver path "com.android.chrome"
 	AndroidPackage string `json:"androidPackage,omitempty"`
 	// Use W3C mode, if true.
-	W3C bool `json:"w3c"`
+	W3C bool `json:"w3c,omitempty"`
 }
 
 // TODO(minusnine): https://bugs.chromium.org/p/chromedriver/issues/detail?id=1625

--- a/chrome/capabilities.go
+++ b/chrome/capabilities.go
@@ -66,7 +66,7 @@ type Capabilities struct {
 	WindowTypes []string `json:"windowTypes,omitempty"`
 	// Android Chrome WebDriver path "com.android.chrome"
 	AndroidPackage string `json:"androidPackage,omitempty"`
-	// Must be true; not useful to consume.
+	// Use W3C mode, if true.
 	W3C bool `json:"w3c"`
 }
 

--- a/selenium.go
+++ b/selenium.go
@@ -94,7 +94,6 @@ type Capabilities map[string]interface{}
 
 // AddChrome adds Chrome-specific capabilities.
 func (c Capabilities) AddChrome(f chrome.Capabilities) {
-	f.W3C = true
 	c[chrome.CapabilitiesKey] = f
 	c[chrome.DeprecatedCapabilitiesKey] = f
 }


### PR DESCRIPTION
Previously, `AddChrome` would quietly override `W3C` to `true`, even if you wanted it to be `false`.

Due to a problem with Chrome, the W3C standard, and `elementIsDisplayed`, it is necessary to be able to disable W3C mode for Chrome so that we can call `IsDisplayed`.

This behavior appears to have started around Chrome 75.

See:

* https://stackoverflow.com/questions/56111529/cannot-call-non-w3c-standard-command-while-in-w3c-mode-seleniumwebdrivererr
* https://github.com/webdriverio/webdriverio/issues/4073