### PR TITLE
Switch to "goog:loggingPrefs" for compatibility with Chrome 75+

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -35,7 +35,10 @@ const (
 
 // CapabilitiesKey is the key for the logging preferences entry in the JSON
 // structure representing WebDriver capabilities.
-const CapabilitiesKey = "loggingPrefs"
+//
+// Note that the W3C spec does not include logging right now, and starting with
+// Chrome 75, "loggingPrefs" has been changed to "goog:loggingPrefs"
+const CapabilitiesKey = "goog:loggingPrefs"
 
 // Capability is the map to include in the WebDriver capabilities structure to
 // configure logging.


### PR DESCRIPTION
Starting with Chrome 75, "loggingPrefs" has been renamed to "goog:loggingPrefs" for W3C compatibility, since logging is not included in the W3C spec yet.