### PR TITLE
Update example to avoid showing go vet warnings

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -69,7 +69,7 @@ func Example() {
 		import "fmt"
 
 		func main() {
-			fmt.Println("Hello WebDriver!\n")
+			fmt.Println("Hello WebDriver!")
 		}
 	`)
 	if err != nil {


### PR DESCRIPTION
Minor fix to help users not get confused by the sneaky go vet warning.

Previous output

```
{
    "value": "./prog.go:6:4: Println arg list ends with redundant newline\nGo vet exited.\n\nHello WebDriver!\n\n\nProgram exited."
}
./prog.go:6:4: Println arg list ends with redundant newline
Go vet exited.
Hello WebDriver!
```

New output

```
{
    "value": "Hello WebDriver!\n\nProgram exited."
}
Hello WebDriver!
```