### PR TITLE
Fixes tebeka/selenium/issues/236

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -1110,11 +1110,7 @@ func (wd *remoteWD) AlertText() (string, error) {
 }
 
 func (wd *remoteWD) SetAlertText(text string) error {
-	data, err := json.Marshal(map[string]string{"text": text})
-	if err != nil {
-		return err
-	}
-
+	data := map[string]string{"text": text}
 	return wd.voidCommand("/session/%s/alert/text", data)
 }
 


### PR DESCRIPTION
The issue tebeka/selenium/issues/236 was happening because the method json.marshal was being called twice on the same data. Once on remote.SetAlertText and again on remote.voidCommand. This currupted the data and resulted in a malformed json wich led to the error on the api call.

I removed the first time json.marshal was called, on the SetAlertText funcion, which then calls the voidCommand  that performs json.marshal and executes the API call. This fixed the bug.