### PR TITLE
Support execute cdp command

### DIFF
--- a/internal/seleniumtest/seleniumtest.go
+++ b/internal/seleniumtest/seleniumtest.go
@@ -1700,7 +1700,29 @@ func testChromeExtension(t *testing.T, c Config) {
 	}
 }
 
+func testChromeCdp(t *testing.T, c Config) {
+	caps := newTestCapabilities(t, c)
+
+	wd, err := NewRemote(t, caps, c.Addr)
+	if err != nil {
+		t.Fatalf("newRemote(_, _) returned error: %v", err)
+	}
+	defer wd.Quit()
+
+	res, err := wd.ExecuteCdpCommand("Browser.getVersion", nil)
+	if err != nil {
+		t.Fatalf("cdp execute error: %s", err.Error())
+	}
+
+	if data, ok := res.(map[string]interface{}); !ok {
+		t.Fatalf("cdp execute failed with result: %v", res)
+	} else {
+		t.Log(data["product"])
+	}
+}
+
 func RunChromeTests(t *testing.T, c Config) {
 	// Chrome-specific tests.
 	t.Run("Extension", runTest(testChromeExtension, c))
+	t.Run("CDP", runTest(testChromeCdp, c))
 }

--- a/selenium.go
+++ b/selenium.go
@@ -370,6 +370,10 @@ type WebDriver interface {
 	// perform JSON decoding.
 	ExecuteScriptAsyncRaw(script string, args []interface{}) ([]byte, error)
 
+	// ExecuteCdpCommand execute Chrome Devtools Protocol command and get returned result
+	// refer to link https://chromedevtools.github.io/devtools-protocol/
+	ExecuteCdpCommand(cmd string, params map[string]interface{}) (interface{}, error)
+
 	// WaitWithTimeoutAndInterval waits for the condition to evaluate to true.
 	WaitWithTimeoutAndInterval(condition Condition, timeout, interval time.Duration) error
 


### PR DESCRIPTION
I run the test cases on a ready-made selenium remote server 
($ docker run -d -p 4444:4444 -v /dev/shm:/dev/shm selenium/standalone-chrome:4.0.0-beta-4-20210608) ,
instead of manually starting a server. 
So I don't know if there are any unknown problems...