### PR TITLE
Add GetProperty function

### DIFF
--- a/internal/seleniumtest/seleniumtest.go
+++ b/internal/seleniumtest/seleniumtest.go
@@ -1118,7 +1118,7 @@ func testGetProperty(t *testing.T, c Config) {
 
 	time.Sleep(500 * time.Millisecond)
 
-	val, err := input.GetProperty("no-such-property")
+	val, err := input.GetProperty("value")
 	if err != nil {
 		t.Fatalf("Error getting property: %v", err)
 	}

--- a/internal/seleniumtest/seleniumtest.go
+++ b/internal/seleniumtest/seleniumtest.go
@@ -1119,8 +1119,6 @@ func testGetProperty(t *testing.T, c Config) {
 		t.Fatalf("Can't send keys: %v", err)
 	}
 
-	time.Sleep(500 * time.Millisecond)
-
 	val, err := input.GetProperty("value")
 	if err != nil {
 		t.Fatalf("Error getting property: %v", err)

--- a/internal/seleniumtest/seleniumtest.go
+++ b/internal/seleniumtest/seleniumtest.go
@@ -1101,6 +1101,9 @@ func testGetAttributeNotFound(t *testing.T, c Config) {
 }
 
 func testGetProperty(t *testing.T, c Config) {
+	if c.Browser == "htmlunit" {
+		t.Skip("Skipping on htmlunit")
+	}
 	wd := newRemote(t, newTestCapabilities(t, c), c)
 	defer quitRemote(t, wd)
 
@@ -1128,6 +1131,9 @@ func testGetProperty(t *testing.T, c Config) {
 }
 
 func testGetPropertyNotFound(t *testing.T, c Config) {
+	if c.Browser == "htmlunit" {
+		t.Skip("Skipping on htmlunit")
+	}
 	wd := newRemote(t, newTestCapabilities(t, c), c)
 	defer quitRemote(t, wd)
 

--- a/internal/seleniumtest/seleniumtest.go
+++ b/internal/seleniumtest/seleniumtest.go
@@ -155,6 +155,8 @@ func RunCommonTests(t *testing.T, c Config) {
 	t.Run("IsSelected", runTest(testIsSelected, c))
 	t.Run("IsDisplayed", runTest(testIsDisplayed, c))
 	t.Run("GetAttributeNotFound", runTest(testGetAttributeNotFound, c))
+	t.Run("GetProperty", runTest(testGetProperty, c))
+	t.Run("GetPropertyNotFound", runTest(testGetPropertyNotFound, c))
 	t.Run("KeyDownUp", runTest(testKeyDownUp, c))
 	t.Run("CSSProperty", runTest(testCSSProperty, c))
 	if !c.SkipProxy {
@@ -1095,6 +1097,50 @@ func testGetAttributeNotFound(t *testing.T, c Config) {
 
 	if _, err = elem.GetAttribute("no-such-attribute"); err == nil {
 		t.Fatal("Got non existing attribute")
+	}
+}
+
+func testGetProperty(t *testing.T, c Config) {
+	wd := newRemote(t, newTestCapabilities(t, c), c)
+	defer quitRemote(t, wd)
+
+	if err := wd.Get(c.ServerURL); err != nil {
+		t.Fatalf("wd.Get(%q) returned error: %v", c.ServerURL, err)
+	}
+	input, err := wd.FindElement(selenium.ByName, "q")
+	if err != nil {
+		t.Fatalf("Can't find element: %v", err)
+	}
+	const query = "golang"
+	if err := input.SendKeys(query); err != nil {
+		t.Fatalf("Can't send keys: %v", err)
+	}
+
+	time.Sleep(500 * time.Millisecond)
+
+	val, err := input.GetProperty("no-such-property")
+	if err != nil {
+		t.Fatalf("Error getting property: %v", err)
+	}
+	if val != query {
+		t.Fatalf("Unexpected property value: %q != %q", val, query)
+	}
+}
+
+func testGetPropertyNotFound(t *testing.T, c Config) {
+	wd := newRemote(t, newTestCapabilities(t, c), c)
+	defer quitRemote(t, wd)
+
+	if err := wd.Get(c.ServerURL); err != nil {
+		t.Fatalf("wd.Get(%q) returned error: %v", c.ServerURL, err)
+	}
+	elem, err := wd.FindElement(selenium.ByID, "chuk")
+	if err != nil {
+		t.Fatal("Can't find element")
+	}
+
+	if _, err = elem.GetProperty("no-such-property"); err == nil {
+		t.Fatal("Got non existing property")
 	}
 }
 

--- a/remote.go
+++ b/remote.go
@@ -1362,7 +1362,12 @@ func (elem *remoteWE) IsDisplayed() (bool, error) {
 	return elem.boolQuery("/session/%%s/element/%s/displayed")
 }
 
-// TODO(minusnine): Add Property(name string) (string, error).
+func (elem *remoteWE) GetProperty(name string) (string, error) {
+	template := "/session/%%s/element/%s/property/%s"
+	urlTemplate := fmt.Sprintf(template, elem.id, name)
+
+	return elem.parent.stringCommand(urlTemplate)
+}
 
 func (elem *remoteWE) GetAttribute(name string) (string, error) {
 	template := "/session/%%s/element/%s/attribute/%s"

--- a/selenium.go
+++ b/selenium.go
@@ -411,6 +411,8 @@ type WebElement interface {
 	IsDisplayed() (bool, error)
 	// GetAttribute returns the named attribute of the element.
 	GetAttribute(name string) (string, error)
+	// GetProperty returns the named attribute of the element.
+	GetProperty(name string) (string, error)
 	// Location returns the element's location.
 	Location() (*Point, error)
 	// LocationInView returns the element's location once it has been scrolled

--- a/selenium.go
+++ b/selenium.go
@@ -409,9 +409,10 @@ type WebElement interface {
 	IsEnabled() (bool, error)
 	// IsDisplayed returns true if the element is displayed.
 	IsDisplayed() (bool, error)
-	// GetAttribute returns the named attribute of the element.
+	// GetAttribute returns the named HTML attribute of the element.
 	GetAttribute(name string) (string, error)
-	// GetProperty returns the named attribute of the element.
+	// GetProperty returns the DOM property of the element. The DOM property
+	// values can change (e.g. input value), the HTML attributes can't.
 	GetProperty(name string) (string, error)
 	// Location returns the element's location.
 	Location() (*Point, error)

--- a/selenium_test.go
+++ b/selenium_test.go
@@ -230,7 +230,7 @@ func TestHTMLUnit(t *testing.T) {
 		// HTMLUnit-Driver currently does not support the sameSite attribute
 		// See: https://github.com/SeleniumHQ/htmlunit-driver/issues/97
 		SameSiteUnsupported: true,
-  }
+	}
 
 	port, err := pickUnusedPort()
 	if err != nil {


### PR DESCRIPTION
The GetProperty method is needed for Chrome 91, because the behavior of GetAttribute has changed.

Issue: https://github.com/tebeka/selenium/issues/248

This pull request also fixes the formatting in `selenium_test.go`