### PR TITLE
Fix some static check warnings

### DIFF
--- a/firefox/capabilities.go
+++ b/firefox/capabilities.go
@@ -65,12 +65,12 @@ type LogLevel string
 // Levels of logging that can be specified in the Log structure.
 const (
 	Trace  LogLevel = "trace"
-	Debug           = "debug"
-	Config          = "config"
-	Info            = "info"
-	Warn            = "warn"
-	Error           = "error"
-	Fatal           = "fatal"
+	Debug  LogLevel = "debug"
+	Config LogLevel = "config"
+	Info   LogLevel = "info"
+	Warn   LogLevel = "warn"
+	Error  LogLevel = "error"
+	Fatal  LogLevel = "fatal"
 )
 
 // Log specifies how Firefox should log debug data.

--- a/internal/seleniumtest/seleniumtest.go
+++ b/internal/seleniumtest/seleniumtest.go
@@ -716,10 +716,6 @@ func testGetCookies(t *testing.T, c Config) {
 	}
 }
 
-func v(s string) semver.Version {
-	return semver.MustParse(s)
-}
-
 func testAddCookie(t *testing.T, c Config) {
 	wd := newRemote(t, newTestCapabilities(t, c), c)
 	defer quitRemote(t, wd)
@@ -1019,7 +1015,7 @@ func testLog(t *testing.T, c Config) {
 				}
 				// Make sure the timestamp conversion is vaguely correct. In
 				// practice, this difference should be in the milliseconds range.
-				if time.Now().Sub(l.Timestamp) > time.Hour {
+				if time.Since(l.Timestamp) > time.Hour {
 					t.Errorf("Message has timestamp %s > 1 hour ago: %v", l.Timestamp, l)
 				}
 			}

--- a/remote.go
+++ b/remote.go
@@ -933,7 +933,7 @@ func (c cookie) sanitize() Cookie {
 			return ""
 		}
 		for _, v := range []SameSite{SameSiteNone, SameSiteLax, SameSiteStrict} {
-			if strings.ToLower(string(v)) == strings.ToLower(s) {
+			if strings.EqualFold(string(v), s) {
 				return v
 			}
 		}

--- a/selenium.go
+++ b/selenium.go
@@ -218,9 +218,9 @@ type SameSite string
 
 const (
 	SameSiteNone   SameSite = "None"
-	SameSiteLax             = "Lax"
-	SameSiteStrict          = "Strict"
-	SameSiteEmpty           = ""
+	SameSiteLax    SameSite = "Lax"
+	SameSiteStrict SameSite = "Strict"
+	SameSiteEmpty  SameSite = ""
 )
 
 // WebDriver defines methods supported by WebDriver drivers.

--- a/selenium_test.go
+++ b/selenium_test.go
@@ -39,7 +39,7 @@ var (
 func TestMain(m *testing.M) {
 	flag.Parse()
 	if err := setDriverPaths(); err != nil {
-		fmt.Fprint(os.Stderr, fmt.Sprintf("Exiting early: unable to get the driver paths -- %s", err.Error()))
+		fmt.Fprintf(os.Stderr, "Exiting early: unable to get the driver paths -- %s", err.Error())
 		os.Exit(1)
 	}
 	os.Exit(m.Run())
@@ -140,13 +140,12 @@ func runChromeTests(t *testing.T, c seleniumtest.Config) {
 	c.Browser = "chrome"
 	c.Headless = *headless
 
-	var opts []selenium.ServiceOption
 	if *startFrameBuffer {
-		opts = append(opts, selenium.StartFrameBuffer())
+		c.ServiceOptions = append(c.ServiceOptions, selenium.StartFrameBuffer())
 	}
 	if testing.Verbose() {
 		selenium.SetDebug(true)
-		opts = append(opts, selenium.Output(os.Stderr))
+		c.ServiceOptions = append(c.ServiceOptions, selenium.Output(os.Stderr))
 	}
 
 	port, err := pickUnusedPort()


### PR DESCRIPTION
firefox/capabilities.go:67:2: only the first constant in this group has an explicit type (SA9004)
internal/seleniumtest/seleniumtest.go:719:6: func v is unused (U1000)
internal/seleniumtest/seleniumtest.go:1022:8: should use time.Since instead of time.Now().Sub (S1012)
remote.go:936:7: should use strings.EqualFold instead (SA6005)
selenium.go:220:2: only the first constant in this group has an explicit type (SA9004)
selenium_test.go:42:3: should use fmt.Fprintf instead of fmt.Fprint(fmt.Sprintf(...)) (S1038)
selenium_test.go:145:10: this result of append is never used, except maybe in other appends (SA4010)
selenium_test.go:149:3: this value of opts is never used (SA4006)
selenium_test.go:149:10: this result of append is never used, except maybe in other appends (SA4010)