### PR TITLE
Added Content-Type request header

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -69,6 +69,7 @@ func newRequest(method string, url string, data []byte) (*http.Request, error) {
 		return nil, err
 	}
 	request.Header.Add("Accept", jsonContentType)
+	request.Header.Add("Content-Type", jsonContentType)
 
 	return request, nil
 }


### PR DESCRIPTION
Apparently, some web drivers cannot accept requests from the clients if the clients don't set correct content type explicitly.
One example is [WinAppDriver](https://github.com/microsoft/WinAppDriver). Without this header it simply returns `500` with a vague message:
`"status":13, "value":{"error":"unknown error", "message":"Object reference not set to an instance of an object."}}`
This single line makes `selenium` work with `WinAppDriver`.