### PR TITLE
add SetW3CCompatibility toggle

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -537,6 +537,10 @@ func (wd *remoteWD) SwitchSession(sessionID string) error {
 	return nil
 }
 
+func (wd *remoteWD) SetW3CCompatibility(isCompatible bool) {
+	wd.w3cCompatible = isCompatible
+}
+
 func (wd *remoteWD) Capabilities() (Capabilities, error) {
 	url := wd.requestURL("/session/%s", wd.id)
 	response, err := wd.execute("GET", url, nil)

--- a/selenium.go
+++ b/selenium.go
@@ -275,6 +275,9 @@ type WebDriver interface {
 	// SwitchSession switches to the given session ID.
 	SwitchSession(sessionID string) error
 
+	// Toggle W3C compliance.
+	SetW3CCompatibility(bool)
+
 	// Capabilities returns the current session's capabilities.
 	Capabilities() (Capabilities, error)
 


### PR DESCRIPTION
Currently it is non-obvious how to get `wd.w3cCompatible` to be `false`.
This happens magically during capabilities parsing.

This change adds an explicit setter to toggle `wd.w3cCompatible`.

This config is needed because not all remotes behave nicely.
Being able to manually set `wd.w3cCompatible` to `false` is an escape hatch for issues with remotes.