### PR TITLE
change URL of chromedriver

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Chrome and [ChromeDriver][chromedriver],
 [go]: http://golang.org/
 [server]: http://seleniumhq.org/download/
 [geckodriver]: https://github.com/mozilla/geckodriver
-[chromedriver]: https://sites.google.com/a/chromium.org/chromedriver/
+[chromedriver]: https://sites.google.com/chromium.org/driver
 [minusnine]: http://github.com/minusnine
 
 ## Installing


### PR DESCRIPTION
The original page says thay have migrated to a new ChromeDriver site