### PR TITLE
Fix MoveTo docs regarding origin for offsets

### DIFF
--- a/selenium.go
+++ b/selenium.go
@@ -442,8 +442,8 @@ type WebElement interface {
 	Submit() error
 	// Clear clears the element.
 	Clear() error
-	// MoveTo moves the mouse to relative coordinates from center of element, If
-	// the element is not visible, it will be scrolled into view.
+	// MoveTo moves the mouse to relative coordinates from the top-left corner of the element.
+	// If the element is not visible, it will be scrolled into view.
 	MoveTo(xOffset, yOffset int) error
 
 	// FindElement finds a child element.


### PR DESCRIPTION
WebElement.MoveTo's documentation stated that the supplied offsets are interpreted relative to the element's center, but this seems to be incorrect. Since remoteWE's implementation always passes "xoffset" and "yoffset" parameters, the offsets are interpreted relative to the element's top-left corner.

---

[The spec](https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidmoveto) states that the mouse is moved to the center of the element if no offsets are supplied, but that offsets are interpreted relative to the top-left corner of the element.

Here's the implementation, which unconditionally passes offsets:

https://github.com/tebeka/selenium/blob/e9100b7f5ac11727841302026707e3961ba14712/remote.go#L1415-L1421

See also #190.